### PR TITLE
Fix typing error for CarouselProvider

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,7 +79,7 @@ type CarouselProviderInterface = React.ComponentClass<CarouselProviderProps>
  * CarouselProvider allows the other carousel components to communicate with each other.
  *
  * The only required properties are:
- * the orientation, naturalSlideWidth, and naturalSlideHeight.
+ * the totalSlides, naturalSlideWidth, and naturalSlideHeight.
  *
  * The naturalSlideWidth and naturalSlideHeight are used
  * to create an aspect ratio for each slide.
@@ -149,7 +149,7 @@ export {
   ButtonNext,
   ButtonPlay,
   CarouselProvider,
-  CarouselState,
+  CarouselProviderProps,
   Dot,
   DotGroup,
   Image,


### PR DESCRIPTION
* fix comment error (`totalSlides` is required instead of `orientation`)
* fix export CarouselProviderState instead of CarouselProviderProps error ( CarouselProviderState is not needed for consumer typing while CarouselProviderProps is)